### PR TITLE
Implement hash-based duplicate ranking

### DIFF
--- a/DupScan.Core/DupScan.Core.csproj
+++ b/DupScan.Core/DupScan.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/DupScan.Core/Services/DuplicateDetector.cs
+++ b/DupScan.Core/Services/DuplicateDetector.cs
@@ -10,9 +10,15 @@ public class DuplicateDetector
     {
         return files
             .GroupBy(f => f.Hash)
-            .Where(g => g.Count() > 1)
-            .Select(g => new DuplicateGroup(g.Key, g))
-            .OrderByDescending(g => g.RecoverableBytes)
+            .Select(g => new
+            {
+                Hash = g.Key,
+                Items = g.ToList(),
+                Recoverable = g.Sum(f => f.Size) - g.Max(f => f.Size)
+            })
+            .Where(g => g.Items.Count > 1)
+            .OrderByDescending(g => g.Recoverable)
+            .Select(g => new DuplicateGroup(g.Hash, g.Items))
             .ToList();
     }
 }

--- a/DupScan.Graph/GraphDriveService.cs
+++ b/DupScan.Graph/GraphDriveService.cs
@@ -30,3 +30,4 @@ public class GraphDriveService : IGraphDriveService
         // TODO: delete the specified item
         return Task.CompletedTask;
     }
+}

--- a/DupScan.Tests/Features/DuplicateDetection.feature
+++ b/DupScan.Tests/Features/DuplicateDetection.feature
@@ -19,8 +19,11 @@ Feature: Duplicate detection
       | 2  | /b   | h1   | 20   |
       | 3  | /c   | h2   | 30   |
       | 4  | /d   | h2   | 40   |
+      | 5  | /e   | h3   | 5    |
+      | 6  | /f   | h3   | 15   |
     When I detect duplicates
     Then groups should be ordered by recoverable bytes
       | Hash | Recoverable |
       | h2   | 30 |
       | h1   | 10 |
+      | h3   | 5  |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 DupScan is an example solution demonstrating a multi-project layout using .NET 9.
 It now includes a core library with duplicate detection logic and BDD tests.
 Duplicate groups are ranked by how many bytes you can reclaim by linking files.
+The `CsvHelper` package is used to export results for further analysis.
 
 ## Projects
 - **DupScan.Core** – domain models and hash-based detection.
@@ -18,17 +19,19 @@ Duplicate groups are ranked by how many bytes you can reclaim by linking files.
 1. Run `dotnet restore` to download dependencies.
 2. Build the solution with `dotnet build DupScan.sln`.
 3. Execute the CLI project using `dotnet run --project DupScan.Cli`.
-4. Run tests with coverage using `dotnet test DupScan.sln --collect:"XPlat Code Coverage"`.
-5. Review coverage results in the generated `TestResults` directory.
-6. Try `dotnet run --project DupScan.Cli` to see duplicate detection in action.
-7. Customize provider roots and enable linking with `--link` and `--parallel` flags.
+4. Install additional packages like `CsvHelper` with `dotnet add <proj> package <name>`.
+5. Run tests with coverage using `dotnet test DupScan.sln --collect:"XPlat Code Coverage"`.
+6. Review coverage results in the generated `TestResults` directory.
+7. Try `dotnet run --project DupScan.Cli` to see duplicate detection in action.
+8. Customize provider roots and enable linking with `--link` and `--parallel` flags.
 
 ## Duplicate Detection
 The core library exposes `FileItem` and `DuplicateGroup` models. The
 `DuplicateDetector` service groups files by hash and calculates the potential
-space savings. Reqnroll scenarios demonstrate how identical hashes are detected
-and ranked by recoverable bytes. Additional unit tests mock Graph responses with
-Moq to validate scanning logic.
+space savings. Groups are ordered by the `RecoverableBytes` value so the most
+impactful duplicates appear first. Reqnroll scenarios demonstrate how identical
+hashes are detected and ranked by recoverable bytes. Additional unit tests mock
+Graph responses with Moq to validate scanning logic.
 
 ## Microsoft Graph Scanning
 `GraphClientFactory` builds a `GraphServiceClient` using `DeviceCodeCredential`.
@@ -47,3 +50,5 @@ credentials. Drive files are converted to `FileItem` objects for detection.
 - Use `--out` to export CSV results via CsvHelper.
 - `--parallel` controls the worker channel degree of parallelism.
 - Specify provider roots to limit scanning to certain directories.
+- Set `DOTNET_CLI_TELEMETRY_OPTOUT=1` to suppress CLI telemetry prompts.
+- Pass `--verbose` to the CLI for detailed logging of scanning operations.


### PR DESCRIPTION
## Summary
- compute recoverable bytes in `DuplicateDetector`
- add CsvHelper package reference
- extend duplicate ranking scenario
- fix missing closing brace in `GraphDriveService`
- expand README guidance

## Testing
- `dotnet build DupScan.sln`
- `dotnet test DupScan.sln --no-build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68543f7dca588330bb66cd3b4257e044