### PR TITLE
Add OAuth flows for cloud services

### DIFF
--- a/DupScan.Google/GoogleClientFactory.cs
+++ b/DupScan.Google/GoogleClientFactory.cs
@@ -1,23 +1,39 @@
 using System.Threading;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;
+using Google.Apis.Util.Store;
 
 namespace DupScan.Google;
 
 public static class GoogleClientFactory
 {
+    /// <summary>
+    /// Creates a <see cref="DriveService"/> using the OAuth desktop flow. A local
+    /// HTTP listener captures the authorization code and the token is cached on
+    /// disk for reuse.
+    /// </summary>
+    /// <param name="clientId">Google Cloud OAuth client ID.</param>
+    /// <param name="clientSecret">Google Cloud OAuth client secret.</param>
+    /// <param name="scopes">Requested Drive scopes.</param>
     public static DriveService Create(string clientId, string clientSecret, string[] scopes)
     {
-        var credential = GoogleWebAuthorizationBroker
-            .AuthorizeAsync(new ClientSecrets
+        var flow = new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
+        {
+            ClientSecrets = new ClientSecrets
             {
                 ClientId = clientId,
                 ClientSecret = clientSecret
             },
-            scopes,
-            "user",
-            CancellationToken.None).Result;
+            Scopes = scopes,
+            DataStore = new FileDataStore("dup-scan-google")
+        });
+
+        var codeReceiver = new LocalServerCodeReceiver();
+        var app = new AuthorizationCodeInstalledApp(flow, codeReceiver);
+        var credential = app.AuthorizeAsync("user", CancellationToken.None).Result;
 
         return new DriveService(new BaseClientService.Initializer
         {

--- a/DupScan.Graph/GraphClientFactory.cs
+++ b/DupScan.Graph/GraphClientFactory.cs
@@ -6,15 +6,23 @@ namespace DupScan.Graph;
 
 public static class GraphClientFactory
 {
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> using the device-code flow.
+    /// The user is prompted to sign in on first use and the access token is
+    /// cached for subsequent requests.
+    /// </summary>
+    /// <param name="tenantId">Azure AD tenant identifier.</param>
+    /// <param name="clientId">Registered client application ID.</param>
+    /// <param name="scopes">Requested Graph permission scopes.</param>
     public static GraphServiceClient Create(string tenantId, string clientId, string[] scopes)
     {
         var options = new DeviceCodeCredentialOptions
         {
             TenantId = tenantId,
             ClientId = clientId,
-            DeviceCodeCallback = (code, ct) =>
+            DeviceCodeCallback = info =>
             {
-                Console.WriteLine(code.Message);
+                Console.WriteLine(info.Message);
                 return Task.CompletedTask;
             }
         };

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ The `CsvHelper` package is used to export results for further analysis.
 7. Try `dotnet run --project DupScan.Cli` to see duplicate detection in action.
 8. Customize provider roots and enable linking with `--link` and `--parallel` flags.
 
+## Authentication Setup
+1. Register a **public client** app in Microsoft Entra ID and note the client ID.
+   Enable the `Files.ReadWrite.All` application permission and grant admin consent.
+2. Create **OAuth desktop** credentials in Google Cloud Console and download the
+   client ID and secret JSON file.
+3. Supply the Graph client ID and tenant ID when constructing the `GraphClientFactory`.
+4. Pass the Google client ID and secret to `GoogleClientFactory.Create` when
+   authenticating.
+5. Cached tokens are stored under `~/.credentials/dup-scan-google` for reuse.
+
 ## Duplicate Detection
 The core library exposes `FileItem` and `DuplicateGroup` models. The
 `DuplicateDetector` service groups files by hash and calculates the potential


### PR DESCRIPTION
## Summary
- implement device-code Graph authentication
- support Google OAuth desktop flow
- document authentication setup for external APIs

## Testing
- `dotnet test DupScan.sln --no-build --no-restore -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6854434545b48330b7d7542518efd97b