### PR TITLE
Add Docker support and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Test
+        run: dotnet test --collect:"XPlat Code Coverage"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/dupscan:latest

--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+**/*.feature.cs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish DupScan.Cli/DupScan.Cli.csproj -c Release -o /app --no-restore
+
+FROM mcr.microsoft.com/dotnet/runtime:9.0
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "DupScan.Cli.dll"]

--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ credentials. Drive files are converted to `FileItem` objects for detection.
 - Specify provider roots to limit scanning to certain directories.
 - Set `DOTNET_CLI_TELEMETRY_OPTOUT=1` to suppress CLI telemetry prompts.
 - Pass `--verbose` to the CLI for detailed logging of scanning operations.
+
+## Docker Usage
+1. If the .NET SDK is missing, run `./dotnet-install.sh` to install locally.
+2. Build the container with `docker build -t dupsan .`.
+3. Run tests inside CI with `dotnet test --collect:"XPlat Code Coverage"`.
+4. Execute the image using `docker run --rm dupsan`.
+5. Provide credentials in `appsettings.json` or mount one via `-v $(pwd)/appsettings.json:/app/appsettings.json`.
+
+These steps show how to run the CLI without installing the SDK globally.
+
+## Improvements
+- Added a ready-to-use `Dockerfile` for container builds.
+- New CI workflow pushes images to Docker Hub.
+- Template `appsettings.json` clarifies required credentials.
+- Documented Docker build and run instructions.
+- Provided a reminder to use `dotnet-install.sh` when needed.

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Graph": {
+    "TenantId": "YOUR_TENANT_ID",
+    "ClientId": "YOUR_CLIENT_ID",
+    "Scopes": ["Files.ReadWrite.All"]
+  },
+  "Google": {
+    "ClientId": "YOUR_GOOGLE_CLIENT_ID",
+    "ClientSecret": "YOUR_GOOGLE_CLIENT_SECRET",
+    "Scopes": ["https://www.googleapis.com/auth/drive"]
+  }
+}


### PR DESCRIPTION
## Summary
- add Dockerfile for building DupScan CLI
- add CI workflow to build, test, and publish Docker image
- provide `appsettings.json` credentials template
- document Docker usage and improvements in README
- ignore generated `*.feature.cs` files

## Testing
- `dotnet test --no-build --no-restore --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_685443472db083309f34843923d19843