### PR TITLE
Implement Google Drive shortcut deletion

### DIFF
--- a/DupScan.Graph/GraphClientFactory.cs
+++ b/DupScan.Graph/GraphClientFactory.cs
@@ -20,7 +20,7 @@ public static class GraphClientFactory
         {
             TenantId = tenantId,
             ClientId = clientId,
-            DeviceCodeCallback = info =>
+            DeviceCodeCallback = (info, _) =>
             {
                 Console.WriteLine(info.Message);
                 return Task.CompletedTask;

--- a/DupScan.Tests/Integration/GoogleWireMockServer.cs
+++ b/DupScan.Tests/Integration/GoogleWireMockServer.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Google.Apis.Drive.v3.Data;
+using GoogleFile = Google.Apis.Drive.v3.Data.File;
 using WireMock.Server;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -17,7 +17,7 @@ public class GoogleWireMockServer : IDisposable
         Server = WireMockServer.Start();
     }
 
-    public void SetupFiles(IEnumerable<File> files)
+    public void SetupFiles(IEnumerable<GoogleFile> files)
     {
         var body = JsonSerializer.Serialize(new { files });
         Server.Given(Request.Create().WithPath("/files").UsingGet())

--- a/DupScan.Tests/Integration/GraphWireMockServer.cs
+++ b/DupScan.Tests/Integration/GraphWireMockServer.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using Microsoft.Graph.Models;
 using WireMock.Server;
-using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
+using WireMockRequest = WireMock.RequestBuilders.Request;
 
 namespace DupScan.Tests.Integration;
 
@@ -20,16 +20,15 @@ public class GraphWireMockServer : IDisposable
     public void SetupChildren(IEnumerable<DriveItem> items)
     {
         var body = JsonSerializer.Serialize(new { value = items });
-        Server.Given(Request.Create().WithPath("/drive/root/children").UsingGet())
+        Server.Given(WireMockRequest.Create().WithPath("/drive/root/children").UsingGet())
               .RespondWith(Response.Create().WithBody(body).WithHeader("Content-Type", "application/json"));
     }
 
     public void ExpectShortcut(string sourceId, string targetId)
     {
-        Server.Given(Request.Create().WithPath($"/drive/items/{sourceId}/shortcut").UsingPost())
-              .WithBody($"{{\"targetId\":\"{targetId}\"}}")
+        Server.Given(WireMockRequest.Create().WithPath($"/drive/items/{sourceId}/shortcut").UsingPost().WithBody($"{{\"targetId\":\"{targetId}\"}}"))
               .RespondWith(Response.Create().WithStatusCode(200));
-        Server.Given(Request.Create().WithPath($"/drive/items/{sourceId}").UsingDelete())
+        Server.Given(WireMockRequest.Create().WithPath($"/drive/items/{sourceId}").UsingDelete())
               .RespondWith(Response.Create().WithStatusCode(200));
     }
 

--- a/DupScan.Tests/Integration/HttpGoogleDriveService.cs
+++ b/DupScan.Tests/Integration/HttpGoogleDriveService.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Google.Apis.Drive.v3.Data;
+using GoogleFile = Google.Apis.Drive.v3.Data.File;
 using DupScan.Google;
 
 namespace DupScan.Tests.Integration;
@@ -13,12 +13,22 @@ public class HttpGoogleDriveService : IGoogleDriveService
         _client = new HttpClient { BaseAddress = new Uri(baseUrl) };
     }
 
-    public async Task<IList<File>> ListFilesAsync()
+    public async Task<IList<GoogleFile>> ListFilesAsync()
     {
         var json = await _client.GetStringAsync("/files");
         var wrapper = JsonSerializer.Deserialize<FilesWrapper>(json);
-        return wrapper?.files ?? new List<File>();
+        return wrapper?.files ?? new List<GoogleFile>();
     }
 
-    private record FilesWrapper(List<File> files);
+    public Task CreateShortcutAsync(string fileId, string targetId)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteFileAsync(string fileId)
+    {
+        return Task.CompletedTask;
+    }
+
+    private record FilesWrapper(List<GoogleFile> files);
 }

--- a/DupScan.Tests/Steps/CsvExportSteps.cs
+++ b/DupScan.Tests/Steps/CsvExportSteps.cs
@@ -18,10 +18,13 @@ public class CsvExportSteps
     {
         foreach (var row in table.Rows)
         {
+            int count = int.Parse(row["Count"]);
+            long recoverable = long.Parse(row["RecoverableBytes"]);
             var files = new List<FileItem>();
-            for (int i = 0; i < int.Parse(row["Count"]); i++)
+            long inc = count > 1 ? recoverable / (count * (count - 1) / 2) : 0;
+            for (int i = 1; i <= count; i++)
             {
-                files.Add(new FileItem(i.ToString(), $"f{i}", row["Hash"], 1));
+                files.Add(new FileItem(i.ToString(), $"f{i}", row["Hash"], i * inc));
             }
             _groups.Add(new DuplicateGroup(row["Hash"], files));
         }

--- a/DupScan.Tests/Unit/GoogleDriveServiceTests.cs
+++ b/DupScan.Tests/Unit/GoogleDriveServiceTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Drive.v3;
+using Google.Apis.Http;
+using Google.Apis.Services;
+using DupScan.Google;
+using Xunit;
+
+namespace DupScan.Tests.Unit;
+
+public class GoogleDriveServiceTests
+{
+    [Fact]
+    public async Task CreateShortcutAsync_makes_expected_requests()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+        var gds = new GoogleDriveService(service);
+
+        await gds.CreateShortcutAsync("1", "2");
+
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+        Assert.Contains("/drive/v3/files/1", handler.Requests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.Contains("/drive/v3/files", handler.Requests[1].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Delete, handler.Requests[2].Method);
+        Assert.Contains("/drive/v3/files/1", handler.Requests[2].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task DeleteFileAsync_makes_delete_request()
+    {
+        var handler = new RecordingHandler();
+        var service = CreateService(handler);
+        var gds = new GoogleDriveService(service);
+
+        await gds.DeleteFileAsync("1");
+
+        var req = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Delete, req.Method);
+        Assert.Contains("/drive/v3/files/1", req.RequestUri!.ToString());
+    }
+
+    private static DriveService CreateService(RecordingHandler handler)
+    {
+        var factory = new HandlerFactory(handler);
+        return new DriveService(new BaseClientService.Initializer
+        {
+            HttpClientFactory = factory,
+            ApplicationName = "test"
+        });
+    }
+
+    private class HandlerFactory : global::Google.Apis.Http.IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public HandlerFactory(HttpMessageHandler handler) => _handler = handler;
+        public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
+        {
+            return new ConfigurableHttpClient(new ConfigurableMessageHandler(_handler));
+        }
+    }
+
+    private class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = new();
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CLI can write summaries with the `--out` option.
 7. Review coverage results in the generated `TestResults` directory.
 8. Try `dotnet run --project DupScan.Cli` to see duplicate detection in action.
 9. Customize provider roots and enable linking with `--link` and `--parallel` flags.
+10. Swap the default HTTP handlers with a custom factory when unit testing service classes.
 
 ## Duplicate Detection
 The core library exposes `FileItem` and `DuplicateGroup` models. The
@@ -57,6 +58,13 @@ BDD scenarios in `DupScan.Tests` validate both scanning and linking workflows us
 `GoogleScanner` uses `GoogleDriveService` to list files via OAuth desktop
 credentials. Drive files are converted to `FileItem` objects for detection.
 The integration server returns stubbed JSON allowing tests to run offline.
+`GoogleDriveService` now creates shortcut files referencing the largest copy and
+removes the duplicates using the Drive API. Unit tests assert that the expected
+HTTP endpoints are invoked for each operation.
+
+When running locally you can swap in the `HttpGoogleDriveService` from the test
+project to point at a mock WireMock server. This makes it easy to develop
+against predictable Drive responses without network access.
 
 ## Extending Scenarios
 Edit the `.feature` files under `DupScan.Tests/Features` to define new cases.
@@ -76,4 +84,9 @@ to model different drive contents.
 - Set `DOTNET_CLI_TELEMETRY_OPTOUT=1` to suppress CLI telemetry prompts.
 - Pass `--verbose` to the CLI for detailed logging of scanning operations.
 - You can inspect generated feature bindings in the `Features` folder to learn how tests are organized.
+- Use the `--link` flag with the Google provider to automatically replace copies
+  with Drive shortcuts.
+- Integration servers under `DupScan.Tests/Integration` make it simple to mock
+  Graph or Google endpoints when experimenting.
+- Run `dotnet test` after adding features to ensure new scenarios remain green.
 


### PR DESCRIPTION
## Summary
- complete GoogleDriveService shortcut logic
- tweak Graph factory callback signature
- update wiremock servers and HTTP Drive service
- fix CSV export step data
- document Google Drive shortcut support
- add GoogleDriveService unit tests

## Testing
- `dotnet build DupScan.sln --no-restore`
- `dotnet test DupScan.sln --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68545d17aa108330a5eec06486093113